### PR TITLE
Kubernetes 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,37 @@
 - Создали файлы манифесты для микросервисов
 - Прошли туториал Kubernetes The Hard way
 - Проверили, что файлы манифесты отрабатывают на созданном класетре kubernetes
+
+## Д/З №21
+- Установили kubectl для работы с Kubernetes API(все, что делает kubectl, можно сделать с помощью HTTP-запросов к API k8s)
+- Установили minikube для разворачивания локальной инсталляции Kubernetes
+- В качестве гипервизора для minikube использовали VirtualBox
+- Развернули наш Minikube-кластер, при этом был автоматически настроен kubectl
+- Создали и запустили Deployment для ui компонента
+- Сделали форвардинг для ui на порт 9292
+- Создали и запустили deployment для компонентов post и comment
+- Создали deployment для mongo, указав ему стандартный volume для хранения информации
+- Для связи компонентов между собой и внешним миром на каждый компонент сделали манифест service(абстракция,
+  которая определяет набор POD-ов (Endpoints) и способ доступа к ним)
+- Создали service для post и comment
+- Создали service для mongodb, т.к. она используется и остальными сервисами
+- Создали дополнительные service для связи post и comment с mongo
+- Создали service для ui компонента, чтобы предоставить доступ к нему снаружи, указав тип сервиса NodePort, по умолчанию все ClusterIP
+- Проверили стандартные аддоны minikube
+- Посмотрели стандартный аддон dashboard от minikube
+- Отделили среду разработки от всего отдельного кластера, создав namespace dev
+- Запустили приложение в dev namespace `kubectl apply -n dev -f .`
+- Добавили информацию об окружении в ui deployment
+- Создали Kubernetes cluster в GCE
+- Подключились к GKE для запуска нашего приложения `gcloud container clusters get-credentials cluster-1 --zone us-central1-a --project docker-182408` 
+- Создали dev namespace в current context(GKE) `kubectl apply -f ./kubernetes/reddit/dev-namespace.yml`
+- Задеплоили все компоненты приложения в dev namespace `kubectl apply -f ./kubernetes/reddit/ -n dev`
+- Открыли reddit для внешнего мира(создав правило брандмауэра)
+- Настроили `Целевые экземпляры - все экземпляры в сети` `Диапазоны IP-адресов источников  - 0.0.0.0/0`
+    `Протоколы и порты - Указанные протоколы и порты tcp:30000-32767`
+- Выбрали свободную ноду из кластера `kubectl get nodes -o wide `
+- Нашли порт публикации service ui ` kubectl describe service ui -n dev | grep NodePort `
+- Проверили работу reddit по адресу `http://<node-ip>:<NodePort>`
+- Также в GKE проверили Dashboard для кластера ` kubectl proxy`
+- Заходим по адресу http://localhost:8001/ui
+- У dashboard не хватает прав, назначаем их `kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard`

--- a/kubernetes/reddit/comment-deployment.yml
+++ b/kubernetes/reddit/comment-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: comment-deployment
+  name: comment
+  labels:
+    app: reddit
+    component: comment
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: comment
+      app: reddit
+      component: comment
   template:
     metadata:
       name: comment
       labels:
-        app: comment
+        app: reddit
+        component: comment
     spec:
       containers:
       - image: donasktello/comment
         name: comment
+        env:
+        - name: COMMENT_DATABASE_HOST
+          value: comment-db

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -2,18 +2,31 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
     spec:
       containers:
-      - image: donasktello/mongo
+      - image: mongo:3.2
         name: mongo
+        volumeMounts:
+        - name: mongo-persistent-storage
+          mountPath: /data/db
+      volumes:
+      - name: mongo-persistent-storage
+        emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -2,18 +2,26 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
     spec:
       containers:
       - image: donasktello/post
         name: post
+        env:
+        - name: POST_DATABASE_HOST
+          value: post-db

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/postdb-service.yml
+++ b/kubernetes/reddit/postdb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -2,18 +2,28 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: ui-deployment
+  name: ui
+  labels:
+    app: reddit
+    component: ui
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
+      app: reddit
+      component: ui
   template:
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
       - image: donasktello/ui
         name: ui
+        env:
+        - name: ENV
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: ui


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- Установили kubectl для работы с Kubernetes API(все, что делает kubectl, можно сделать с помощью HTTP-запросов к API k8s)
- Установили minikube для разворачивания локальной инсталляции Kubernetes
- В качестве гипервизора для minikube использовали VirtualBox
- Развернули наш Minikube-кластер, при этом был автоматически настроен kubectl
- Создали и запустили Deployment для ui компонента
- Сделали форвардинг для ui на порт 9292
- Создали и запустили deployment для компонентов post и comment
- Создали deployment для mongo, указав ему стандартный volume для хранения информации
- Для связи компонентов между собой и внешним миром на каждый компонент сделали манифест service(абстракция,
  которая определяет набор POD-ов (Endpoints) и способ доступа к ним)
- Создали service для post и comment
- Создали service для mongodb, т.к. она используется и остальными сервисами
- Создали дополнительные service для связи post и comment с mongo
- Создали service для ui компонента, чтобы предоставить доступ к нему снаружи, указав тип сервиса NodePort, по умолчанию все ClusterIP
- Проверили стандартные аддоны minikube
- Посмотрели стандартный аддон dashboard от minikube
- Отделили среду разработки от всего отдельного кластера, создав namespace dev
- Запустили приложение в dev namespace `kubectl apply -n dev -f .`
- Добавили информацию об окружении в ui deployment
- Создали Kubernetes cluster в GCE
- Подключились к GKE для запуска нашего приложения `gcloud container clusters get-credentials cluster-1 --zone us-central1-a --project docker-182408` 
- Создали dev namespace в current context(GKE) `kubectl apply -f ./kubernetes/reddit/dev-namespace.yml`
- Задеплоили все компоненты приложения в dev namespace `kubectl apply -f ./kubernetes/reddit/ -n dev`
- Открыли reddit для внешнего мира(создав правило брандмауэра)
- Настроили `Целевые экземпляры - все экземпляры в сети` `Диапазоны IP-адресов источников  - 0.0.0.0/0`
    `Протоколы и порты - Указанные протоколы и порты tcp:30000-32767`
- Выбрали свободную ноду из кластера `kubectl get nodes -o wide `
- Нашли порт публикации service ui ` kubectl describe service ui -n dev | grep NodePort `
- Проверили работу reddit по адресу `http://<node-ip>:<NodePort>`
- Также в GKE проверили Dashboard для кластера ` kubectl proxy`
- Заходим по адресу http://localhost:8001/ui
- У dashboard не хватает прав, назначаем их `kubectl create clusterrolebinding kubernetes-dashboard  --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard`

## Как запустить проект:
 - Создать kubernetes кластер в GCE и задеплоить все файлы

## Как проверить работоспособность:
 - перейти по ссылке reddit по адресу `http://<node-ip>:<NodePort>`

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания